### PR TITLE
plane intersection -- throw error rather than null

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,3 @@
+install:
+  - mvn wrapper:wrapper -Dmaven=3.9.9
+  - ./mvnw -B install -DskipTests

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,36 @@
 					<target>1.8</target>
 				</configuration>
 			</plugin>
-
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>3.3.0</version>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<phase>deploy</phase>
+						<goals>
+							<goal>jar-no-fork</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>3.11.2</version>
+				<configuration>
+					<failOnError>false</failOnError>
+				</configuration>
+				<executions>
+					<execution>
+						<id>attach-javadocs</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 				<configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 				<executions>
 					<execution>
 						<id>attach-sources</id>
-						<phase>deploy</phase>
+						<phase>package</phase>
 						<goals>
 							<goal>jar-no-fork</goal>
 						</goals>

--- a/src/org/twak/utils/geom/LinearForm3D.java
+++ b/src/org/twak/utils/geom/LinearForm3D.java
@@ -174,7 +174,7 @@ public class LinearForm3D implements Cloneable
     }
     
     /**
-     * Finds the intersection point of three planes in 3D space.
+     * Finds the intersection point between this plane and two others in 3D space.
      */
     public Tuple3d collide(final LinearForm3D b, final LinearForm3D c) {
     	final LinearForm3D a = this;
@@ -189,8 +189,8 @@ public class LinearForm3D implements Cloneable
                     + a.C * (b.A * c.B - b.B * c.A);
                     
         // Check if planes are parallel/coincident (no single intersection point)
-        if (Math.abs(det) < 1e-10) {
-            return null;
+        if (det == 0) {
+        	throw new Error("Planes do not intersect at a single point.");
         }
         
         // Use Cramer's rule to solve the system


### PR DESCRIPTION
On no plane intersection, throw error, rather than return null, since skeleton code handles no intersection by wrapping this in try-catch, rather than null-checking.

Also made maven attach javadoc+source to .jar.